### PR TITLE
fix: use RequestInit from node-fetch instead of inbuilt typescript

### DIFF
--- a/src/utils/auth.util.ts
+++ b/src/utils/auth.util.ts
@@ -1,11 +1,14 @@
 import { SonarQubeSDKAuth } from '../interfaces';
+import { RequestInit } from 'node-fetch'
 
 export class AuthUtils {
   static setAuthInHeadersIfConfigured = (auth?: SonarQubeSDKAuth) => {
-    const options: Record<string, string> = {};
+    const options: RequestInit = {};
     if (auth) {
-      options['Authorization'] =
-        'Basic ' + this.getBaseEncodedAuthCredentials(auth);
+      const headersInit: HeadersInit = {};
+      headersInit.Authorization =
+      'Basic ' + this.getBaseEncodedAuthCredentials(auth);
+      options.headers = headersInit;
     }
     return options;
   };


### PR DESCRIPTION
Fix based on this stackoverflow answer https://stackoverflow.com/a/67870352/5868851

The issue was that the call `sonarqube-sdk/src/base/config.base.ts:fetch(url, init)` would'nt succeed even if the parameters are good (tested with `curl` and `postman`), which would result in an error.

The fix is to pass a `RequestInit` parameter for `init`, which make the call to fetch succeed.